### PR TITLE
Allow folder names with spaces

### DIFF
--- a/tools/npm.cmd
+++ b/tools/npm.cmd
@@ -1,3 +1,3 @@
 @echo off
-for /f "delims=" %%A in ('dir %~dp0..\..\node.js.* /b') do set "nodePath=%%A"
+for /f "delims=" %%A in ('dir "%~dp0..\..\node.js.*" /b') do set "nodePath=%%A"
 "%~dp0..\..\%nodePath%\node.exe" "%~dp0node_modules\npm\bin\npm-cli.js" %*


### PR DESCRIPTION
As PerLindenAddiva pointed out in issue #2 this will fail if you have space in folder name.
