### PR TITLE
Update npm.js.targets

### DIFF
--- a/build/npm.js.targets
+++ b/build/npm.js.targets
@@ -19,7 +19,7 @@
       echo VS 12 Common Tools not found
       )
       set PATH=$(MSBuildThisFileDirectory)..\tools\;%PATH%
-      "$(MSBuildThisFileDirectory)..\tools\npm install"
+      "$(MSBuildThisFileDirectory)..\tools\npm" install
       ]]></NpmExec>
   </PropertyGroup>
 	<Target Name="RestoreNpmPkgs">


### PR DESCRIPTION
Fix invalid syntax which is causing build failures. Seems as if there's an orphaned `"` in the `npm install` command string
