### PR TITLE
Do not run npm targets when NCrunch is building the project.

### DIFF
--- a/build/npm.js.targets
+++ b/build/npm.js.targets
@@ -24,7 +24,7 @@
   </PropertyGroup>
 	<Target Name="RestoreNpmPkgs">
 		<Message Text="Restoring NPM packages..." Condition="'$(DONT_INSTALL_NPM)' == ''"/>
-    <Exec Command="$(NpmExec)" Condition="'$(DONT_INSTALL_NPM)' == ''" />
+    <Exec Command="$(NpmExec)" Condition="'$(DONT_INSTALL_NPM)' == '' AND '$(NCrunch)' != '1'" />
 		<Message Text="NPMs not installed, environment variable 'DONT_INSTALL_NPM' set." Condition="'$(DONT_INSTALL_NPM)' != ''" />
 		<Message Text="NPM packages restored!" Condition="'$(DONT_INSTALL_NPM)' == ''"/>
     </Target>


### PR DESCRIPTION
NCrunch (http://www.ncrunch.net/) is a popular continuous test runner.
The npm targets currently prevent it from building the project.
